### PR TITLE
feature: Created `SettingsManager` and implemented three default engine settings.

### DIFF
--- a/Notes.nt
+++ b/Notes.nt
@@ -252,3 +252,11 @@ I finished up by creating the command line (although, not sure if I really need 
 At my parents' house, I tested the code and made some small changes and a few fixes. Mainly, I fixed a lot of off-by-one/direction errors; this ended up fixing that weird bug where the first input wasn't being processed. Basically, the variable that stores the last processed queue index was being incremented incorrectly; I was adding one less than the size of the safe queue to it every time I processed events, which made the check for if it was a valid index return false on the first input. My resoning for this, at the time, was simply trying to keep the index at the last processed index (i.e: one less than the size of the queue), but the way that I use it to test queue validity only works if it ends on the index for the next event (i.e: the size of the queue). This also makes sure that the last event processed for a frame doesn't get processed again at the start of the next frame.
 
 I also changed the print color variables; they're more verbose and less modular, but a lot simpler/easier to use.
+
+[08/15/25]
+I'm gonna first check that everything I worked on last is working and I am ready to move on from it; then, I want to start working on a UI system. I'll probably heavily integrate DearImGui, so I may want to streamline the ImGui integration within my backend system.
+
+Ooh, before the UI stuff, I want to make sure my printouts are the ones from my "ctrl" repo and tidy up anything else that's in 'common/' or is otherwise a "helper".
+
+[08/17/25]
+I created 'SettingsManager', and implemented three default engine settings (tick rate, tick interval, and app name).

--- a/src/common/safe_return.hpp
+++ b/src/common/safe_return.hpp
@@ -29,18 +29,19 @@ private:
 
 struct Status
 {
-    inline static SafeStatus NO_ERROR                               = SafeStatus( 0b00000000000, "NO_ERROR"                               );
-    inline static SafeStatus ERROR_GENERIC                          = SafeStatus( 0b10000000000, "ERROR_GENERIC"                          );
-    inline static SafeStatus ERROR_ALREADY_ACTIVE                   = SafeStatus( 0b01000000000, "ERROR_ALREADY_ACTIVE"                   );
-    inline static SafeStatus ERROR_INVALID_KEY_ID                   = SafeStatus( 0b00100000000, "ERROR_INVALID_KEY_ID"                   );
-    inline static SafeStatus WindowingBackendWINDOW_CREATION_FAILED = SafeStatus( 0b00010000000, "WindowingBackendWINDOW_CREATION_FAILED" );
-    inline static SafeStatus EventQueueNOT_ENABLED                  = SafeStatus( 0b00001000000, "EventQueueNOT_ENABLED"                  );
-    inline static SafeStatus EventQueueNOT_PROCESSING_EVENTS        = SafeStatus( 0b00000100000, "EventQueueNOT_PROCESSING_EVENTS"        );
-    inline static SafeStatus EventQueueEMPTY                        = SafeStatus( 0b00000010000, "EventQueueEMPTY"                        );
-    inline static SafeStatus InputManagerKEY_NOT_FOUND              = SafeStatus( 0b00000001000, "InputManagerKEY_NOT_FOUND"              );
-    inline static SafeStatus InputManagerKEY_IS_LOCKED              = SafeStatus( 0b00000000100, "InputManagerKEY_IS_LOCKED"              );
-    inline static SafeStatus CommandLineINVALID_COMMAND             = SafeStatus( 0b00000000010, "CommandLineINVALID_COMMAND"             );
-    inline static SafeStatus KeyBindsKEY_HAS_NO_BINDS               = SafeStatus( 0b00000000001, "KeyBindsKEY_HAS_NO_BINDS"               );
+    inline static SafeStatus NO_ERROR                               = SafeStatus( 0b000000000000, "NO_ERROR"                               );
+    inline static SafeStatus ERROR_GENERIC                          = SafeStatus( 0b100000000000, "ERROR_GENERIC"                          );
+    inline static SafeStatus ERROR_ALREADY_ACTIVE                   = SafeStatus( 0b010000000000, "ERROR_ALREADY_ACTIVE"                   );
+    inline static SafeStatus ERROR_INVALID_KEY_ID                   = SafeStatus( 0b001000000000, "ERROR_INVALID_KEY_ID"                   );
+    inline static SafeStatus WindowingBackendWINDOW_CREATION_FAILED = SafeStatus( 0b000100000000, "WindowingBackendWINDOW_CREATION_FAILED" );
+    inline static SafeStatus EventQueueNOT_ENABLED                  = SafeStatus( 0b000010000000, "EventQueueNOT_ENABLED"                  );
+    inline static SafeStatus EventQueueNOT_PROCESSING_EVENTS        = SafeStatus( 0b000001000000, "EventQueueNOT_PROCESSING_EVENTS"        );
+    inline static SafeStatus EventQueueEMPTY                        = SafeStatus( 0b000000100000, "EventQueueEMPTY"                        );
+    inline static SafeStatus InputManagerKEY_NOT_FOUND              = SafeStatus( 0b000000010000, "InputManagerKEY_NOT_FOUND"              );
+    inline static SafeStatus InputManagerKEY_IS_LOCKED              = SafeStatus( 0b000000001000, "InputManagerKEY_IS_LOCKED"              );
+    inline static SafeStatus CommandLineINVALID_COMMAND             = SafeStatus( 0b000000000100, "CommandLineINVALID_COMMAND"             );
+    inline static SafeStatus KeyBindsKEY_HAS_NO_BINDS               = SafeStatus( 0b000000000010, "KeyBindsKEY_HAS_NO_BINDS"               );
+    inline static SafeStatus SettingsManagerINVALID_SETTING_NAME    = SafeStatus( 0b000000000001, "SettingsManagerINVALID_SETTING_NAME"    );
 };
 
 template<typename T>

--- a/src/managers/manager.cpp
+++ b/src/managers/manager.cpp
@@ -1,5 +1,6 @@
 #include "manager.hpp"
 #include "printing.hpp"
+#include "settings/settings_manager.hpp"
 
 #include <GLFW/glfw3.h>
 #include <cassert>
@@ -193,7 +194,7 @@ void _Manager::Tick()
         auto now = std::chrono::steady_clock::now();
         auto duration = now - start_time;
         double current_time = std::chrono::duration<double>(duration).count();
-        current_tick_length += (current_time - last_time) / TICK_INTERVAL;
+        current_tick_length += (current_time - last_time) / SettingsManager::unsafe_GetSetting<float>(Settings::Engine::sName_TickInterval);
         last_time = current_time;
 
         while(current_tick_length >= 1.0f)

--- a/src/managers/manager.hpp
+++ b/src/managers/manager.hpp
@@ -20,10 +20,6 @@ enum TheatreReturnValue_t
     FINISHED,
 };
 
-// Tick rate and interval. Done this way for convenience and so I can change the tick rate more easily at the expense of negligable compile time(?)
-#define TICK_RATE 70 // If DOOM did it at 70hz then so can you
-#define TICK_INTERVAL ( 1.0f / TICK_RATE )
-
 // Basic idea taken from Valve's Source Engine, specifically the file -> (src/app/legion/gamemanager.h)
 class _Manager
 {

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -1,0 +1,64 @@
+#include "settings_manager.hpp"
+
+std::map<std::string, std::string> SettingsManager::m_StringSettings =
+{
+    { Settings::Engine::sName_AppName, Settings::Engine::sDefault_AppName },
+};
+
+std::map<std::string, int> SettingsManager::m_IntSettings =
+{
+    { Settings::Engine::sName_TickRate, Settings::Engine::sDefault_TickRate },
+};
+
+std::map<std::string, float> SettingsManager::m_FloatSettings =
+{
+    { Settings::Engine::sName_TickInterval, Settings::Engine::sDefault_TickInterval },
+};
+
+void SettingsManager::SetSetting(const std::string& setting_name, const std::string& setting)
+{ m_StringSettings[setting_name] = setting; }
+
+void SettingsManager::SetSetting(const std::string& setting_name, int setting)
+{ m_IntSettings[setting_name] = setting; }
+
+void SettingsManager::SetSetting(const std::string& setting_name, float setting)
+{ m_FloatSettings[setting_name] = setting; }
+
+template<>
+SafeReturn<std::string> SettingsManager::try_GetSetting(const std::string& setting_name)
+{
+    if(!m_StringSettings.contains(setting_name))
+    { return SafeReturn<std::string>("", Status::SettingsManagerINVALID_SETTING_NAME); }
+
+    return SafeReturn(m_StringSettings.at(setting_name));
+}
+
+template<>
+SafeReturn<int> SettingsManager::try_GetSetting(const std::string& setting_name)
+{
+    if(!m_IntSettings.contains(setting_name))
+    { return SafeReturn(-1, Status::SettingsManagerINVALID_SETTING_NAME); }
+
+    return SafeReturn(m_IntSettings.at(setting_name));
+}
+
+template<>
+SafeReturn<float> SettingsManager::try_GetSetting(const std::string& setting_name)
+{
+    if(!m_StringSettings.contains(setting_name))
+    { return SafeReturn(-1.0f, Status::SettingsManagerINVALID_SETTING_NAME); }
+
+    return SafeReturn(m_FloatSettings.at(setting_name));
+}
+
+template<>
+std::string SettingsManager::unsafe_GetSetting(const std::string& setting_name)
+{ return m_StringSettings.at(setting_name); }
+
+template<>
+int SettingsManager::unsafe_GetSetting(const std::string& setting_name)
+{ return m_IntSettings.at(setting_name); }
+
+template<>
+float SettingsManager::unsafe_GetSetting(const std::string& setting_name)
+{ return m_FloatSettings.at(setting_name); }

--- a/src/settings/settings_manager.hpp
+++ b/src/settings/settings_manager.hpp
@@ -1,0 +1,52 @@
+#ifndef SETTINGS_MANAGER_H
+#define SETTINGS_MANAGER_H
+
+#include "safe_return.hpp"
+
+#include <map>
+#include <string>
+
+class SettingsManager
+{
+public:
+    static void SetSetting(const std::string& SettingName, const std::string& Setting);
+    static void SetSetting(const std::string& SettingName, float Setting);
+    static void SetSetting(const std::string& SettingName, int Setting);
+
+    template<typename T>
+    static SafeReturn<T> try_GetSetting(const std::string& SettingName);
+    template<> SafeReturn<std::string> try_GetSetting(const std::string& SettingName);
+    template<> SafeReturn<float>       try_GetSetting(const std::string& SettingName);
+    template<> SafeReturn<int>         try_GetSetting(const std::string& SettingName);
+
+private:
+    static std::map<std::string, std::string> m_StringSettings;
+    static std::map<std::string, int>         m_IntSettings;
+    static std::map<std::string, float>       m_FloatSettings;
+
+    // 'unsafe_GetSetting' is only to be used when the setting is GUARANTEED to exist as it performs no safety checks (for maximum performance)
+    // An example use case would be: _Manager using `unsafe_GetSetting` to get the tick interval every frame
+    friend struct _Manager;
+    template<typename T>
+    static T unsafe_GetSetting(const std::string& SettingName);
+    template<> std::string unsafe_GetSetting(const std::string& SettingName);
+    template<> float       unsafe_GetSetting(const std::string& SettingName);
+    template<> int         unsafe_GetSetting(const std::string& SettingName);
+};
+
+struct Settings
+{
+    struct Engine
+    {
+        // Setting Names
+        static constexpr const char* sName_AppName  = "Nostalgia Game Engine";
+        static constexpr const char* sName_TickRate = "TickRate";
+        static constexpr const char* sName_TickInterval = "TickInterval";
+        // Setting Default Values
+        static constexpr const char* sDefault_AppName  = "Nostalgia Game Engine";
+        static constexpr int         sDefault_TickRate = 70;
+        static constexpr int         sDefault_TickInterval = (1.0f / sDefault_TickRate);
+    };
+};
+
+#endif // SETTINGS_MANAGER_H


### PR DESCRIPTION
SettingsManager is pretty much just an abstraction for interacting with three different maps of "settings". Settings are just pairs of string names and string/float/integer values. I use template functions for getting settings, and overloaded functions for setting settings. I've also included three private function templates for getting settings that are "unsafe"; they don't check if the setting name exists in the map and just try to return a value. These functions should only be used by parts of the engine where speed is absolutely critical, hence why they're private. As an example use case for these unsafe functions,`_Manager` uses them to get the tick interval on every frame.