### PR TITLE
feature+refactor(Theatre parsing)

### DIFF
--- a/src/common/ids.hpp
+++ b/src/common/ids.hpp
@@ -1,22 +1,24 @@
 #ifndef IDS_H
 #define IDS_H
 
+#include "embedded/names.hpp"
 #include "frozen/map.h"
 
 #include <string>
 #include <format>
+#include <map>
 
 typedef unsigned int id_t;
 
 struct ID
 {
 public:
-    constexpr ID(const id_t& id): id_(id) {}
+    constexpr ID(const id_t& id = None): id_(id) {}
 
     constexpr operator const id_t&() const
     { return id_; }
 
-    static constexpr id_t None    = static_cast<unsigned int>(-2);    // Same as `UINT_MAX - 1`
+    static constexpr id_t None    = static_cast<unsigned int>(-2); // Same as `UINT_MAX - 1`
     static constexpr id_t Invalid = static_cast<unsigned int>(-1); // Same as `UINT_MAX`
     static constexpr id_t front   = 0;
     static constexpr id_t back    = None - 1;
@@ -62,6 +64,21 @@ struct UniqueIDs
         // Boundaries
         static constexpr ID front = Player;
         static constexpr ID back  = f_Audiowide;
+
+        inline static const std::map<std::string, id_t>
+        ResourceNameToUIDMap =
+        {
+            { Images::Name::Missing,    i_Missing    },
+            { Images::Name::LightDebug, i_LightDebug },
+            { Images::Name::COMP04_5,   i_COMP04_5   },
+            { Images::Name::LolBit,     i_LolBit     },
+            { Models::Name::Error,      m_Error      },
+            { Models::Name::Cube,       m_Cube       },
+            { Models::Name::Ramiel,     m_Ramiel     },
+            { Fonts::Name::Audiowide,   f_Audiowide  },
+            { Fonts::Name::DejaVuSans,  f_DejaVuSans },
+            { Fonts::Name::Verdana,     f_Verdana    },
+        };
     };
 
     // Boundaries

--- a/src/common/unique_id.cpp
+++ b/src/common/unique_id.cpp
@@ -4,12 +4,11 @@
 #include <random>
 #include <set>
 
-static constexpr unsigned int cMaxUniqueIDs = (UniqueIDs::back - UniqueIDs::Reserved::back); // Probably one less than the real max but it shouldn't matter
-
 static std::random_device sRandomSeed;
 static std::mt19937 sIdEngine(sRandomSeed());
-static std::uniform_int_distribution<id_t> sIdDistribution(UniqueIDs::front, UniqueIDs::back);
-static std::set<ID> sExistingIDs = {};
+static std::uniform_int_distribution<id_t> sIdDistribution{UniqueIDs::front, UniqueIDs::back};
+static std::set<ID> sExistingIDs{};
+static constexpr unsigned int cMaxUniqueIDs{UniqueIDs::back - UniqueIDs::Reserved::back}; // Probably one less than the real max but it shouldn't matter
 
 ID UniqueIDs::Generate()
 {

--- a/src/managers/theatre_manager.cpp
+++ b/src/managers/theatre_manager.cpp
@@ -244,7 +244,12 @@ void TheatreManager::CreateThings()
     g_pBackendManager->Graphics()->BufferMesh({Models::Cube, std::size(Models::Cube), FileType::model_OBJ}, UniqueIDs::Reserved::m_Cube);
     g_pBackendManager->Graphics()->BufferMesh({Models::Ramiel, std::size(Models::Ramiel), FileType::model_OBJ}, UniqueIDs::Reserved::m_Ramiel);
 
-    for(const ThingData& data : sCurrentTheatreData.GetData())
+    sCurrentTheatreData.SetupUIDsAndPriorities();
+    DEBUG(sCurrentTheatreData.debug_PrintData();)
+    PRINT_DEBUG("Reconstructed Theatre File:")
+    std::println("{}", sCurrentTheatreData.formatted());
+
+    for(ThingData& data : sCurrentTheatreData.things_data)
         { CreateThing(data); }
 
     s_ReadyToRender = true;

--- a/src/theatre_parser/theatre_data.cpp
+++ b/src/theatre_parser/theatre_data.cpp
@@ -1,46 +1,13 @@
 #include "theatre_data.hpp"
-#include "embedded/names.hpp"
 #include "things/thing_factory.hpp"
 #include "colors.hpp"
+
+#include <map>
 
 const TheatreData TheatreData::Missing;
 
 ID TheatreData::id() const
 { return id_; }
-
-const std::vector<ThingData>& TheatreData::GetData() const
-{ return data_; }
-
-static std::map<std::string, ID>
-s_EmbeddedDataNameIDLookup =
-{
-    { Images::Name::Missing,    UniqueIDs::Reserved::i_Missing    },
-    { Images::Name::LightDebug, UniqueIDs::Reserved::i_LightDebug },
-    { Images::Name::COMP04_5,   UniqueIDs::Reserved::i_COMP04_5   },
-    { Images::Name::LolBit,     UniqueIDs::Reserved::i_LolBit     },
-    { Models::Name::Error,      UniqueIDs::Reserved::m_Error      },
-    { Models::Name::Cube,       UniqueIDs::Reserved::m_Cube       },
-    { Models::Name::Ramiel,     UniqueIDs::Reserved::m_Ramiel     },
-    { Fonts::Name::Audiowide,   UniqueIDs::Reserved::f_Audiowide  },
-    { Fonts::Name::DejaVuSans,  UniqueIDs::Reserved::f_DejaVuSans },
-    { Fonts::Name::Verdana,     UniqueIDs::Reserved::f_Verdana    },
-};
-
-void TheatreData::UpdateReferences(const std::map<std::string, std::string>& ids)
-{
-    for(ThingData& data : data_)
-    {
-        for(ThingVar& variable : data.variables)
-        {
-            if(variable.type != ThingVar::eReferenceT || variable.type != ThingVar::eReferenceE)
-                { continue; }
-            if(ids.contains(variable.value))
-                { variable.value = ids.at(variable.value); }
-            else if(s_EmbeddedDataNameIDLookup.contains(variable.value))
-                { variable.value = std::to_string(s_EmbeddedDataNameIDLookup.at(variable.value)); }
-        }
-    }
-}
 
 // QuickSort functions heavily plagiarized from: https://www.w3schools.com/dsa/dsa_algo_quicksort.php
 static int s_DataPartition(std::vector<ThingData>& array, int low, int high)
@@ -75,14 +42,36 @@ static void s_DataQuickSort(std::vector<ThingData>& array, int low, int high)
     }
 }
 
-void TheatreData::OrderByPriority()
-{ s_DataQuickSort(data_, 0, data_.size() - 1); }
+void TheatreData::SetupUIDsAndPriorities()
+{
+    s_DataQuickSort(things_data, 0, things_data.size() - 1);
+
+    std::map<std::string, id_t> name_id_map{UniqueIDs::Reserved::ResourceNameToUIDMap};
+    UniqueIDs::Clear();
+
+    // I wanted to combine these two `for` loops, but it's safer to separate them, since I can't guarantee that
+    // referenced things will have defined UIDs even after sorting by priority. Perhaps in the future I can change
+    // this, but for now it's fine to have two for loops (even if I personally hate it).
+    for(ThingData& data : things_data)
+        { name_id_map[data.name] = data.uid = UniqueIDs::Generate(); }
+
+    for(ThingData& data : things_data)
+    {
+        for(ThingVar& variable : data.variables)
+        {
+            if(variable.type != ThingVar::eReferenceT && variable.type != ThingVar::eReferenceE)
+                { continue; }
+            else if(name_id_map.contains(variable.value))
+                { variable.reference_id = name_id_map.at(variable.value); }
+        }
+    }
+}
 
 SafeStatus TheatreData::AddData(const ThingData& data)
 {
     if(!ThingFactory::IsThing(data.type()))
         { return Status::TheatreDataINVALID_TYPE; }
-    data_.push_back(data);
+    things_data.push_back(data);
     return Status::NO_ERR;
 }
 
@@ -90,29 +79,28 @@ std::string TheatreData::formatted() const
 {
     std::string resources("");
     std::string things("");
-
-    for(const auto& thing_data : data_)
+    for(const ThingData& thing_data : things_data)
     {
-        if(ThingFactory::IsResource(thing_data.uid) && !thing_data.variables.empty())
-            { resources += std::format("\t{} {} = {}", ThingFactory::GetTypeName(thing_data.uid), name, thing_data.variables.at(0).formatted_value()); }
+        std::println("thing_data.uid == {}", thing_data.type());
+        if(ThingFactory::IsResource(thing_data.type()) && !thing_data.variables.empty())
+            { resources += std::format("\t{} {} = {}\n", ThingFactory::GetTypeName(thing_data.type()), thing_data.name, thing_data.variables.at(0).formatted_value()); }
         else
         {
-            things += std::format("\t{} {}\n\t{{\n", ThingFactory::GetTypeName(thing_data.uid), name);
-            for(const auto& variable : thing_data.variables)
-                { things += std::format("\t\t{}\n", variable.formatted_value()); }
+            things += std::format("\t{} {}\n\t{{\n", ThingFactory::GetTypeName(thing_data.type()), thing_data.name);
+            for(const ThingVar& variable : thing_data.variables)
+                { things += std::format("\t\t{} = {}\n", variable.name, variable.formatted_value()); }
             things += std::format("\t}}\n");
         }
     }
-
     return std::format("@{}#{}\n\nResources\n{{\n{}}}\n\nThings\n{{\n{}}}\n", name, index, resources, things);
 }
 
 void TheatreData::clear()
-{ data_.clear(); }
+{ things_data.clear(); }
 
 void TheatreData::debug_PrintData()
 {
     std::println("{}Theatre Data Printout:{}", sty::Bold + fg::Cyan, sty::Reset);
-    for(const auto& data : data_)
-        { std::println("{}", data.log(true, true)); }
+    for(const ThingData& thing_data : things_data)
+        { std::println("{}", thing_data.log(true, true)); }
 }

--- a/src/theatre_parser/theatre_data.hpp
+++ b/src/theatre_parser/theatre_data.hpp
@@ -6,20 +6,16 @@
 #include "ids.hpp"
 #include "thing_data.hpp"
 #include "safe_return.hpp"
-#include "frozen/string.h"
-
-#include <map>
 
 struct TheatreData
 {
     static const TheatreData Missing;
 
-    frozen::string name = "TheatreData";
+    std::vector<ThingData> things_data{};
+    std::string name{"UntitledTheatre"};
     int index = -1;
 
-    const std::vector<ThingData>& GetData() const;
-    void UpdateReferences(const std::map<std::string, std::string>& NameIDMap);
-    void OrderByPriority();
+    void SetupUIDsAndPriorities();
 
     SafeStatus AddData(const ThingData& Data);
 
@@ -32,7 +28,6 @@ struct TheatreData
     { return (id_ == Other.id_); }
 
 private:
-    std::vector<ThingData> data_ = {};
     ID id_ = ID::None;
 };
 

--- a/src/theatre_parser/theatre_parser.cpp
+++ b/src/theatre_parser/theatre_parser.cpp
@@ -103,20 +103,19 @@ bool TheatreParser::ParseTheatreFileFromMemory(const FileData& data, TheatreData
     return ReadTheatre(output);
 }
 
-bool TheatreParser::WriteTheatre(const TheatreData& data, const std::string& path)
+SafeReturn<std::string> TheatreParser::WriteTheatre(const TheatreData& data, const std::string& file_path)
 {
-    return FileSystem::try_WriteFileFromString(path,data.formatted());
+    std::string final_path = (FileSystem::HasStem(file_path)) ? file_path : FileSystem::Directory(file_path) + data.name;
+    return SafeReturn(final_path, FileSystem::try_WriteFileFromString(final_path, data.formatted()));
 }
 
 bool TheatreParser::ReadTheatre(TheatreData& output)
 {
 #   pragma message("TODO: If/when I decide to make Theatres an object and allow for multiple Theatres to be loaded, I need a way of storing/clearing *only* that Theatre's IDs (probably as a range?)")
-    UniqueIDs::Clear();
-    std::map<std::string, std::string> name_id_map = {};
 
-    TheatreData theatre_data;
-    ThingData   temp_data;
-    ThingData   temp_data_swap;
+    ThingData temp_data;
+    ThingData temp_data_swap;
+    output.clear();
 
     COLUMN = 1;
     LINE   = 1;
@@ -133,7 +132,6 @@ bool TheatreParser::ReadTheatre(TheatreData& output)
     bool inside_string    = false;
     bool invalid_context  = false;
     bool set_new_line     = false;
-    bool has_player_actor = false;
 
     std::string theatre_name  = "";
     std::string theatre_index = "";
@@ -313,7 +311,7 @@ bool TheatreParser::ReadTheatre(TheatreData& output)
             continue;
         case newline:
             set_new_line = true;
-            inside_comment  = false;
+            inside_comment = false;
             if(location == Location::TopLevel)
             {
                 if(defining == Defining::Name)
@@ -356,42 +354,27 @@ bool TheatreParser::ReadTheatre(TheatreData& output)
                 defining = Defining::Variable;
                 location = Location::Object;
                 parsing  = Parsing::VariableName;
-            }
 
-            if(temp_data.type() == ThingType::NostalgiaPlayer)
-                { has_player_actor = true; temp_data.uid = UniqueIDs::Reserved::Player; }
-            else
-                { temp_data.uid = UniqueIDs::Generate(); }
-            theatre_data.AddData(temp_data);
-            name_id_map[temp_data.name] = std::to_string(temp_data.uid);
+                output.AddData(temp_data);
 
-            if(location == Location::Sandwich)
-            {
                 std::string sandwich_variable_value = temp_data.name;
                 temp_data = temp_data_swap;
                 temp_data.AddVariable(sandwich_variable_name, sandwich_variable_value, ThingVar::eReferenceT);
 
                 temp_data_swap.clear();
                 sandwich_variable_name.clear();
+                continue;
             }
 
+            output.AddData(temp_data);
             temp_data.clear();
             variable_name.clear();
             variable_value.clear();
             continue;
         }
-
         buffer += character;
     }
-
-    if(!has_player_actor)
-        { theatre_data.AddData(ThingData::PlayerDefaults); }
-
-    theatre_data.UpdateReferences(name_id_map);
-    theatre_data.OrderByPriority();
-
-    DEBUG(theatre_data.debug_PrintData();)
-    output = theatre_data;
-    theatre_data.clear();
+    output.name = theatre_name;
+    StringToNum(output.index, theatre_index);
     return true;
 }

--- a/src/theatre_parser/theatre_parser.hpp
+++ b/src/theatre_parser/theatre_parser.hpp
@@ -4,13 +4,14 @@
 #include "filesystem/fwd.hpp"
 
 #include "theatre_data.hpp"
+#include "safe_return.hpp"
 
 struct TheatreParser
 {
 public:
     static bool ParseTheatreFile(const std::string& FilePath, TheatreData& Output);
     static bool ParseTheatreFileFromMemory(const FileData& FileData, TheatreData& Output);
-    static bool WriteTheatre(const TheatreData& TheatreData, const std::string& FilePath);
+    static SafeReturn<std::string> WriteTheatre(const TheatreData& TheatreData, const std::string& OutputPath);
 
 private:
     static FileData m_sTheatreFile;

--- a/src/theatre_parser/thing_data.cpp
+++ b/src/theatre_parser/thing_data.cpp
@@ -82,11 +82,7 @@ bool ThingData::GetReference(ID& output, const std::string& name) const
 {
     if(auto assert_var = AssertVariable(name, {ThingVar::eReferenceE, ThingVar::eReferenceT});
         SafeStatus::Check(assert_var.Status()))
-    {
-        unsigned int id = output;
-        if(StringToNum<unsigned int>(id, assert_var.Data()->value))
-            { output = id; return true; }
-    }
+        { output = assert_var.Data()->reference_id; return true; }
     return false;
 }
 

--- a/src/theatre_parser/thing_variable.hpp
+++ b/src/theatre_parser/thing_variable.hpp
@@ -3,6 +3,7 @@
 
 #include "penum_t.hpp"
 #include "colors.hpp"
+#include "ids.hpp"
 
 #include <string>
 #include <format>
@@ -12,6 +13,7 @@ struct ThingVar
     std::string name{"Untitled ThingVar"};
     std::string value{""};
     penum_t     type{eNothing};
+    ID reference_id{ID::None};
 
     static constexpr penum_t eNothing    { 0, "Nothing"   };
     static constexpr penum_t eReferenceT { 1, "TheatreReference" };
@@ -42,9 +44,9 @@ struct ThingVar
     std::string log(bool colored = false) const
     {
         if(colored)
-            { return std::format("{2}({5}){0} {1}{3}{0} == {4}", sty::Reset, sty::Bold + fg::Green, sty::Bold + fg::Yellow, name, value, type); }
+            { return std::format("{2}({5}){0} {1}{3}{0} == {4}", sty::Reset, sty::Bold + fg::Green, sty::Bold + fg::Yellow, name, formatted_value(), type); }
         else
-            { return std::format("({2}) {0} == {1}", name, value, type); }
+            { return std::format("({2}) {0} == {1}", name, formatted_value(), type); }
     }
 
     constexpr bool operator==(const std::string& VarName) const


### PR DESCRIPTION
…s, UID setup, Theatre file writing, and data formatting

`ThingVar`
    - Added `reference_id` member to store a UID, if the variable is a reference - Now, `value` does not get changed and can be easily used to re-create the variable when writing a Theatre file from `TheatreData`
    - Fixed `log` function
        - Swapped out `value` for `formatted_value()`

`ThingData`
    - Utilized new `ThingVar::reference_id` member in `GetReference`

`TheatreParser`
    - Re-wrote `WriteTheatre` functions as one function - Mainly, it now takes one string as a file path and determines whether it's a path to a directory or to a file; the Theatre's name is used/unused based on that information
    - Slimmed down parsing function
        - Removed reference updating, player tracking, and priority ordering code - References and priorities are still set by `TheatreData`, but are now called in `TheatreManager` - Player tracking is not necessary, since `TheatreManager::CreateThing` will fill the player with default values before calling `Setup`
        - Set `TheatreData` name and index

`TheatreData`
    - Made `data_` public and renamed it to `things_data`
    - Merged `UpdateReferences` and `OrderByPriority` into `SetupUIDsAndPriorities`

`TheatreManager`
    - Implemented new Theatre parsing code

`UniqueIDs`
    - Added new const map which maps the names of pre-defined Resources (e.g: `Images::Name::Missing`) to their reserved UIDs - This is used by `TheatreData::SetupUIDsAndPriorites` when setting up references to these special Resources - These Resources are unique/special to the engine so they shouldn't change very much and definitely shouldn't be changed externally