### PR TITLE
refactor(VariableRegistry)

### DIFF
--- a/Nostalgia/theatre/variable_registry.cpp
+++ b/Nostalgia/theatre/variable_registry.cpp
@@ -216,7 +216,7 @@ bool VariableRegistry::HasResourceData(ID inID)
     return false;
 }
 
-Error VariableRegistry::RegisterResourceData(ID& outID,
+Error VariableRegistry::RegisterResourceData(ID inID,
     UID::ReservedType inType,
     Sarg inName,
     Farg<Shared<FileData>> inData,
@@ -231,9 +231,9 @@ Error VariableRegistry::RegisterResourceData(ID& outID,
                 { return ERR_ALREADY_EXISTS; }
         }
     }
-    if(auto status{UID::CreateReservedUID(inType, outID)}; not status)
+    if(auto status{UID::CreateReservedUID(inType, inID)}; not status)
         { return status; }
-    m_sResourceData[{outID(), inName}] = inData;
+    m_sResourceData[{inID(), inName}] = inData;
     return OK;
 }
 

--- a/Nostalgia/theatre/variable_registry.hpp
+++ b/Nostalgia/theatre/variable_registry.hpp
@@ -45,7 +45,7 @@ public:
     static Shared<FileData> GetResourceData(ID inID);
     static bool HasResourceData(Sarg inName);
     static bool HasResourceData(ID inID);
-    static Error RegisterResourceData(ID& outID, UID::ReservedType inType, Sarg inName, Farg<Shared<FileData>> inData, bool doNoCopies = true);
+    static Error RegisterResourceData(ID inID, UID::ReservedType inType, Sarg inName, Farg<Shared<FileData>> inData, bool doNoCopies = true);
     static Error RemoveResourceData(Sarg inName);
     static Error RemoveResourceData(ID inID);
     static void ClearResourceData();


### PR DESCRIPTION
rename and change pass-by-reference to avoid confusion

Leaving the ID reference in `RegisterResourceData(ID& outID,...` was a mistake, but doesn't actually cause any issues other than confusion. This leads me to consider doing the very ill-advised thing of pushing this hotfix, changing which commit the v0.6.0 tag is on, recompiling the libraries, and quietly replacing the zip files in the release without anyone (hopefully) noticing...